### PR TITLE
Convert GetSceneUidList from Object to int[]

### DIFF
--- a/GILua/src/main/java/org/anime_game_servers/gi_lua/script_lib/ScriptLib.java
+++ b/GILua/src/main/java/org/anime_game_servers/gi_lua/script_lib/ScriptLib.java
@@ -364,15 +364,8 @@ public class ScriptLib {
         return context.getScriptLibHandler().SetGroupReplaceable(context, groupId, value);
     }
 
-    public static Object GetSceneUidList(GroupEventLuaContext context){
-        val list = context.getScriptLibHandler().GetSceneUidList(context);
-
-        val result = context.getEngine().createTable();
-
-        for(int i = 0; i< list.length; i++){
-            result.set(Integer.toString(i+1), list[i]);
-        }
-        return result;
+    public static int[] GetSceneUidList(GroupEventLuaContext context){
+        return context.getScriptLibHandler().GetSceneUidList(context);
     }
 
     public static int GetSeaLampActivityPhase(GroupEventLuaContext context){
@@ -902,7 +895,7 @@ public class ScriptLib {
     }
 
     public static Object GetRotationByEntityId(GroupEventLuaContext context, int entityId){
-        val rot = context.getScriptLibHandler().GetPosByEntityId(context, entityId);
+        val rot = context.getScriptLibHandler().GetRotationByEntityId(context, entityId);
         return posToLua(rot, context.getEngine()).getRawTable();
     }
 


### PR DESCRIPTION
At the end of the childe battle (m1023), the battle abruptly ends and you are left alone in the dungeon.

This error happens in the console:
```
03:05:39 <ERROR:SceneScriptManager> [LUA] call trigger failed in group 220101001 with condition_EVENT_TIMER_EVENT_1035,org.anime_game_servers.gi_lua.models.ScriptArgs@68959ac0
org.terasology.jnlua.LuaRuntimeException: null:241: org.terasology.jnlua.LuaRuntimeException: attempt to read class org.anime_game_servers.jnlua_engine.JNLuaTable with accessor '1' (undefined)
	at org.terasology.jnlua.LuaState53.lua_pcall(Native Method)
	at org.terasology.jnlua.LuaState.call(LuaState.java:734)
	at org.terasology.jnlua.script.LuaScriptEngine.invokeFunction(LuaScriptEngine.java:181)
	at org.anime_game_servers.jnlua_engine.JNLuaScript.callMethod(JNLuaScript.java:123)
	at emu.grasscutter.scripts.SceneScriptManager.callScriptFunc(SceneScriptManager.java:845)
	at emu.grasscutter.scripts.SceneScriptManager.evaluateTriggerCondition(SceneScriptManager.java:787)
	at emu.grasscutter.scripts.SceneScriptManager.handleEventForTrigger(SceneScriptManager.java:760)
	at emu.grasscutter.scripts.SceneScriptManager.realCallEvent(SceneScriptManager.java:749)
	at emu.grasscutter.scripts.SceneScriptManager.lambda$callEvent$29(SceneScriptManager.java:737)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: org.terasology.jnlua.LuaRuntimeException: attempt to read class org.anime_game_servers.jnlua_engine.JNLuaTable with accessor '1' (undefined)
	at org.terasology.jnlua.DefaultJavaReflector$Index.invoke(DefaultJavaReflector.java:419)
	at org.terasology.jnlua.LuaState$2.invoke(LuaState.java:314)
	... 16 common frames omitted
```

Line 241 is the IsPlayerAllAvatarDie here:
```lua
function condition_EVENT_TIMER_EVENT_1035(context, evt)
	local uid=ScriptLib.GetSceneUidList(context)
	if ScriptLib.IsPlayerAllAvatarDie(context, uid[1]) then
	return false
	end
	return true
end
```



I know in lua, LuaTables are arrays and can be accessed with [], but for funzies I went to https://github.com/Hartie95/AnimeGamesLua/blob/1950a70e71dbd6b2d9fa3f41e0546633226742eb/GILua/src/main/java/org/anime_game_servers/gi_lua/script_lib/ScriptLib.java#L367 and made GetSceneUidList into a int[] instead of a object or LuaTable, figured out how to compile it (that was a trip) and it worked! it's even passing to that IsPlayerAllAvatarDie correctly: `03:37:11 <WARN:ScriptLibHandler> [LUA] Call unimplemented IsPlayerAllAvatarDie 10001`

I went and made this bug report for it:
https://github.com/Anime-Game-Servers/Grasscutter-Quests/pull/114


Was there a reason you had it this way?



After, I started getting this, but I think this has more to do with your implementation of Position/Vector
```
<ERROR:emu.grasscutter.scripts.SceneScriptManager> [LUA] call trigger failed in group 220101001 with action_EVENT_TIMER_EVENT_1033,org.anime_game_servers.gi_lua.models.ScriptArgs@5a53b51f
org.terasology.jnlua.LuaRuntimeException: null:231: org.terasology.jnlua.LuaRuntimeException: attempt to read class java.util.HashMap with accessor 'y' (undefined)
	at org.terasology.jnlua.LuaState53.lua_pcall(Native Method)
	at org.terasology.jnlua.LuaState.call(LuaState.java:734)
	at org.terasology.jnlua.script.LuaScriptEngine.invokeFunction(LuaScriptEngine.java:181)
	at org.anime_game_servers.jnlua_engine.JNLuaScript.callMethod(JNLuaScript.java:123)
	at emu.grasscutter.scripts.SceneScriptManager.callScriptFunc(SceneScriptManager.java:845)
	at emu.grasscutter.scripts.SceneScriptManager.callTrigger(SceneScriptManager.java:796)
	at emu.grasscutter.scripts.SceneScriptManager.handleEventForTrigger(SceneScriptManager.java:761)
	at emu.grasscutter.scripts.SceneScriptManager.realCallEvent(SceneScriptManager.java:749)
	at emu.grasscutter.scripts.SceneScriptManager.lambda$callEvent$29(SceneScriptManager.java:737)
	at java.base/java.util.concurrent.Executors$RunnableAdapter.call(Executors.java:539)
	at java.base/java.util.concurrent.FutureTask.run$$$capture(FutureTask.java:264)
	at java.base/java.util.concurrent.FutureTask.run(FutureTask.java)
	at java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1136)
	at java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:635)
	at io.netty.util.concurrent.FastThreadLocalRunnable.run(FastThreadLocalRunnable.java:30)
	at java.base/java.lang.Thread.run(Thread.java:833)
Caused by: org.terasology.jnlua.LuaRuntimeException: attempt to read class java.util.HashMap with accessor 'y' (undefined)
	at org.terasology.jnlua.DefaultJavaReflector$Index.invoke(DefaultJavaReflector.java:419)
	at org.terasology.jnlua.LuaState$2.invoke(LuaState.java:314)
	... 16 common frames omitted
```

I couldn't make that one go away, but it doesn't seem to be having an effect on anything.